### PR TITLE
Fix: add default cube on create page to prevent black screen

### DIFF
--- a/website/studio.js
+++ b/website/studio.js
@@ -239,15 +239,13 @@ class PrimitiveStudio {
             primitivesBar.style.display = 'flex';
         }
 
-        // Only add default cube and show primitives if in 'new' mode
-        if (mode === 'new') {
-            // Add a default cube so the scene isn't empty/dark
-            if (this.model.MeshCount() === 0) {
-                this.primitivesManager.GenerateMaterial = () => this.primitivesManager.CreatePhysicalMaterial();
-                this.primitivesManager.CreatePrimitive('cube');
-                this.viewer.SetModel(this.model);
-                this.focusOnModel();
-            }
+        // Add a default cube on page load if scene is empty to prevent black screen
+        if (this.model.MeshCount() === 0) {
+            this.primitivesManager.GenerateMaterial = () => this.primitivesManager.CreatePhysicalMaterial();
+            this.primitivesManager.CreatePrimitive('cube');
+            this.viewer.SetModel(this.model);
+            this.focusOnModel();
+        }
         }
 
         this.initDebugOverlay();


### PR DESCRIPTION
## Summary
- always add a default cube when the scene is empty on the create page
- avoid black screen by ensuring at least one mesh is present

## Testing
- open website/create.html with an empty scene -> a cube appears and camera fits
- verified primitives bar still shows and URL mode parameter is not required