### PR TITLE
SSH tabanlı statik deploy: script + workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,8 +8,9 @@ name: Deploy to SiteGround
 #   SSH_USERNAME     SSH username
 #   SSH_PRIVATE_KEY  private key contents (a passphrase-less key is recommended for CI)
 #   DEPLOY_PATH      absolute web root, e.g. /home/<account>/www/kreacad.fabus.app/public_html
-# Optional secret:
+# Optional secrets:
 #   SSH_PORT         SSH port (defaults to 22; SiteGround commonly uses 18765)
+#   SSH_PASSPHRASE   passphrase for SSH_PRIVATE_KEY, if the key is encrypted
 
 on:
   push:
@@ -46,5 +47,6 @@ jobs:
           SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
           SSH_PORT: ${{ secrets.SSH_PORT }}
           SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          SSH_PASSPHRASE: ${{ secrets.SSH_PASSPHRASE }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
         run: bash ./tools/deploy.sh

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,13 +1,24 @@
 name: Deploy to SiteGround
 
-# kreacad.fabus.app -> SiteGround public_html
-# Pushes to the "master" branch are deployed automatically.
-# You can also trigger it manually from the Actions tab (workflow_dispatch).
+# Builds the static site and deploys dist/ to kreacad.fabus.app over SSH (rsync).
+# Pushes to master deploy automatically; can also be run manually (workflow_dispatch).
+#
+# Required repository secrets (Settings -> Secrets and variables -> Actions):
+#   SSH_HOST         server host (e.g. kreacad.fabus.app or the SiteGround IP)
+#   SSH_USERNAME     SSH username
+#   SSH_PRIVATE_KEY  private key contents (a passphrase-less key is recommended for CI)
+#   DEPLOY_PATH      absolute web root, e.g. /home/<account>/www/kreacad.fabus.app/public_html
+# Optional secret:
+#   SSH_PORT         SSH port (defaults to 22; SiteGround commonly uses 18765)
 
 on:
   push:
     branches: [master]
   workflow_dispatch:
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: true
 
 jobs:
   deploy:
@@ -16,25 +27,24 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Stage files (exclude VCS / dev files)
-        run: |
-          mkdir -p _deploy
-          rsync -a \
-            --exclude='.git' \
-            --exclude='.github' \
-            --exclude='.vscode' \
-            --exclude='_deploy' \
-            ./ _deploy/
-
-      - name: Upload to SiteGround via SSH
-        uses: appleboy/scp-action@v0.1.7
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          host: ${{ secrets.SSH_HOST }}
-          port: ${{ secrets.SSH_PORT }}
-          username: ${{ secrets.SSH_USERNAME }}
-          key: ${{ secrets.SSH_PRIVATE_KEY }}
-          passphrase: ${{ secrets.SSH_PASSPHRASE }}
-          source: "_deploy/."
-          target: ${{ secrets.DEPLOY_PATH }}
-          strip_components: 1
-          overwrite: true
+          node-version: 20.x
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Build static site
+        run: |
+          npm run build_engine
+          npm run create_dist
+
+      - name: Deploy dist/ to server over SSH
+        env:
+          SSH_HOST: ${{ secrets.SSH_HOST }}
+          SSH_USERNAME: ${{ secrets.SSH_USERNAME }}
+          SSH_PORT: ${{ secrets.SSH_PORT }}
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+        run: bash ./tools/deploy.sh

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+#
+# Static SSH deploy for KreaCAD.
+# Uploads the built static site (dist/) to the web server over SSH using rsync.
+#
+# Required environment variables:
+#   SSH_HOST       Server hostname or IP           (e.g. kreacad.fabus.app)
+#   SSH_USERNAME   SSH user                         (e.g. u1234-myaccount)
+#   DEPLOY_PATH    Absolute web root on the server  (e.g. /home/customer/www/kreacad.fabus.app/public_html)
+#
+# Optional environment variables:
+#   SSH_PORT          SSH port (default: 22; SiteGround commonly uses 18765)
+#   SSH_PRIVATE_KEY   Private key contents. When set it is written to a temp file
+#                     and used for auth (CI). When unset, your local ssh-agent /
+#                     ~/.ssh keys are used instead (handy for manual runs).
+#   DIST_DIR          Local directory to upload (default: dist)
+#   DEPLOY_DELETE     "true" (default) removes remote files no longer present locally.
+#   DRY_RUN           "true" performs a trial run printing changes without making them.
+#
+# Usage:
+#   npm run build_engine && npm run create_dist   # produce dist/
+#   SSH_HOST=... SSH_USERNAME=... DEPLOY_PATH=... ./tools/deploy.sh
+set -euo pipefail
+
+DIST_DIR="${DIST_DIR:-dist}"
+SSH_PORT="${SSH_PORT:-22}"
+DEPLOY_DELETE="${DEPLOY_DELETE:-true}"
+DRY_RUN="${DRY_RUN:-false}"
+
+require() {
+  local name="$1"
+  if [ -z "${!name:-}" ]; then
+    echo "ERROR: required environment variable '$name' is not set." >&2
+    exit 1
+  fi
+}
+
+require SSH_HOST
+require SSH_USERNAME
+require DEPLOY_PATH
+
+if [ ! -d "$DIST_DIR" ]; then
+  echo "ERROR: '$DIST_DIR' does not exist. Build it first: npm run build_engine && npm run create_dist" >&2
+  exit 1
+fi
+
+# Isolated, always-cleaned-up SSH setup so we never touch ~/.ssh.
+TMP_DIR="$(mktemp -d)"
+KEY_FILE="$TMP_DIR/deploy_key"
+KNOWN_HOSTS="$TMP_DIR/known_hosts"
+cleanup() { rm -rf "$TMP_DIR"; }
+trap cleanup EXIT
+
+# Pin the host key with ssh-keyscan so strict checking passes without an
+# interactive prompt (instead of disabling host-key verification entirely).
+if ! ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" > "$KNOWN_HOSTS" 2>/dev/null || [ ! -s "$KNOWN_HOSTS" ]; then
+  echo "ERROR: could not fetch host key for $SSH_HOST:$SSH_PORT" >&2
+  exit 1
+fi
+
+SSH_OPTS=(-p "$SSH_PORT" -o "UserKnownHostsFile=$KNOWN_HOSTS" -o "StrictHostKeyChecking=yes")
+
+# Use an explicit key file when the private key is provided (CI); otherwise the
+# user's ssh-agent / default keys are used.
+if [ -n "${SSH_PRIVATE_KEY:-}" ]; then
+  printf '%s\n' "$SSH_PRIVATE_KEY" > "$KEY_FILE"
+  chmod 600 "$KEY_FILE"
+  SSH_OPTS+=(-i "$KEY_FILE" -o "IdentitiesOnly=yes")
+fi
+
+# -rlptz: recursive, symlinks, permissions, times, compress.
+# (Intentionally not -a: owner/group/device preservation tends to fail on shared hosting.)
+RSYNC_ARGS=(-rlptz --human-readable)
+[ "$DEPLOY_DELETE" = "true" ] && RSYNC_ARGS+=(--delete-after)
+[ "$DRY_RUN" = "true" ] && RSYNC_ARGS+=(--dry-run --verbose)
+
+echo "Deploying $DIST_DIR/ -> $SSH_USERNAME@$SSH_HOST:$DEPLOY_PATH (port $SSH_PORT, delete=$DEPLOY_DELETE, dry_run=$DRY_RUN)"
+
+# Trailing slash on the source copies the *contents* of dist/ into DEPLOY_PATH.
+rsync "${RSYNC_ARGS[@]}" -e "ssh ${SSH_OPTS[*]}" "$DIST_DIR/" "$SSH_USERNAME@$SSH_HOST:$DEPLOY_PATH/"
+
+echo "Deploy complete."

--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -13,6 +13,9 @@
 #   SSH_PRIVATE_KEY   Private key contents. When set it is written to a temp file
 #                     and used for auth (CI). When unset, your local ssh-agent /
 #                     ~/.ssh keys are used instead (handy for manual runs).
+#   SSH_PASSPHRASE    Passphrase protecting SSH_PRIVATE_KEY. When set, the key is
+#                     loaded into a throwaway ssh-agent so rsync can authenticate
+#                     non-interactively.
 #   DIST_DIR          Local directory to upload (default: dist)
 #   DEPLOY_DELETE     "true" (default) removes remote files no longer present locally.
 #   DRY_RUN           "true" performs a trial run printing changes without making them.
@@ -48,7 +51,10 @@ fi
 TMP_DIR="$(mktemp -d)"
 KEY_FILE="$TMP_DIR/deploy_key"
 KNOWN_HOSTS="$TMP_DIR/known_hosts"
-cleanup() { rm -rf "$TMP_DIR"; }
+cleanup() {
+  [ -n "${SSH_AGENT_PID:-}" ] && ssh-agent -k >/dev/null 2>&1 || true
+  rm -rf "$TMP_DIR"
+}
 trap cleanup EXIT
 
 # Pin the host key with ssh-keyscan so strict checking passes without an
@@ -65,7 +71,23 @@ SSH_OPTS=(-p "$SSH_PORT" -o "UserKnownHostsFile=$KNOWN_HOSTS" -o "StrictHostKeyC
 if [ -n "${SSH_PRIVATE_KEY:-}" ]; then
   printf '%s\n' "$SSH_PRIVATE_KEY" > "$KEY_FILE"
   chmod 600 "$KEY_FILE"
-  SSH_OPTS+=(-i "$KEY_FILE" -o "IdentitiesOnly=yes")
+
+  if [ -n "${SSH_PASSPHRASE:-}" ]; then
+    # Passphrase-protected key: load it into a throwaway ssh-agent so rsync can
+    # authenticate without a TTY. A tiny SSH_ASKPASS helper feeds the passphrase.
+    eval "$(ssh-agent -s)" >/dev/null
+    ASKPASS="$TMP_DIR/askpass.sh"
+    printf '#!/bin/sh\nprintf "%%s\\n" "$SSH_PASSPHRASE"\n' > "$ASKPASS"
+    chmod 700 "$ASKPASS"
+    if ! SSH_ASKPASS="$ASKPASS" SSH_ASKPASS_REQUIRE=force DISPLAY=":0" \
+         ssh-add "$KEY_FILE" </dev/null >/dev/null 2>&1; then
+      echo "ERROR: failed to load the SSH key — is SSH_PASSPHRASE correct?" >&2
+      exit 1
+    fi
+    # Authenticate via the agent (it holds only this freshly-loaded key).
+  else
+    SSH_OPTS+=(-i "$KEY_FILE" -o "IdentitiesOnly=yes")
+  fi
 fi
 
 # -rlptz: recursive, symlinks, permissions, times, compress.


### PR DESCRIPTION
## Amaç

`kreacad.fabus.app` (SiteGround) için **SSH tabanlı statik deploy** — yeniden kullanılabilir bir script ve build edip yalnızca `dist/`'i sunucuya gönderen bir GitHub Actions workflow'u.

Önceki `deploy.yml` tüm repo kökünü (`source/`, `test/`, `tools/`, `.md`, `package.json` vb. dahil) `scp-action` ile gönderiyordu; build adımı ve eski dosyaları temizleme yoktu. Bu PR onu düzgün bir statik deploy ile değiştiriyor.

## Değişiklikler

**`tools/deploy.sh`** — rsync-over-SSH deploy script'i (CI'de ve yerelde çalışır):
- Yalnızca build edilmiş `dist/` klasörünü gönderir.
- Host anahtarını `ssh-keyscan` ile sabitler — host-key doğrulamasını kapatmak yerine (`StrictHostKeyChecking=yes`).
- İzole, otomatik temizlenen geçici key/known_hosts kullanır (`~/.ssh`'a dokunmaz).
- `--delete-after` ile sunucudaki artık olmayan dosyaları temizler (kapatılabilir: `DEPLOY_DELETE=false`).
- `DRY_RUN=true` ile deneme modu.
- CI'de `SSH_PRIVATE_KEY` secret'ı, yerelde ssh-agent/varsayılan anahtarlar ile çalışır.
- Eksik değişkenlerde ve `dist/` yoksa net hata verir.

**`.github/workflows/deploy.yml`**:
- `npm install` → `npm run build_engine` → `npm run create_dist` ile statik siteyi üretir.
- `bash ./tools/deploy.sh` ile `dist/`'i SSH üzerinden gönderir.
- `push: master` ve `workflow_dispatch` tetikleyicileri + `concurrency` guard'ı.

## Gerekli repository secret'ları

`Settings → Secrets and variables → Actions`:

| Secret | Açıklama |
|--------|----------|
| `SSH_HOST` | Sunucu host'u (örn. `kreacad.fabus.app` veya SiteGround IP'si) |
| `SSH_USERNAME` | SSH kullanıcı adı |
| `SSH_PRIVATE_KEY` | Özel anahtar içeriği (CI için passphrase'siz anahtar önerilir) |
| `DEPLOY_PATH` | Mutlak web kök yolu, örn. `/home/<hesap>/www/kreacad.fabus.app/public_html` |
| `SSH_PORT` *(opsiyonel)* | SSH portu (varsayılan 22; SiteGround genelde **18765**) |

> Not: SiteGround panelinden bir SSH anahtarı oluşturup public kısmını sunucuya yetkilendir, private kısmını `SSH_PRIVATE_KEY` secret'ına koy. Doğru `DEPLOY_PATH`'i SiteGround → Site Tools → Devs → SSH Keys / File Manager üzerinden teyit edebilirsin.

## Test

- `bash -n tools/deploy.sh` → sözdizimi OK.
- Eksik değişken guard'ı doğrulandı (temiz hata + exit 1).
- `npm run build_engine` ve `npm run create_dist` lokalde başarıyla `dist/`'i üretti.

İlk deploy'u doğrulamak için secret'lar eklendikten sonra Actions sekmesinden workflow'u manuel (`Run workflow`) tetikleyeb' veya `DRY_RUN` ile deneyebilirsin.

https://claude.ai/code/session_019fFDYGgTsqemsWxwDkjHj5

---
_Generated by [Claude Code](https://claude.ai/code/session_019fFDYGgTsqemsWxwDkjHj5)_