### PR TITLE
Deploy: ssh-keyscan başarısızlığına dayanıklılık + teşhis

### DIFF
--- a/tools/deploy.sh
+++ b/tools/deploy.sh
@@ -57,14 +57,20 @@ cleanup() {
 }
 trap cleanup EXIT
 
-# Pin the host key with ssh-keyscan so strict checking passes without an
-# interactive prompt (instead of disabling host-key verification entirely).
-if ! ssh-keyscan -p "$SSH_PORT" -H "$SSH_HOST" > "$KNOWN_HOSTS" 2>/dev/null || [ ! -s "$KNOWN_HOSTS" ]; then
-  echo "ERROR: could not fetch host key for $SSH_HOST:$SSH_PORT" >&2
-  exit 1
+# Best-effort: pre-fetch and pin the host key so strict checking can be used.
+# If ssh-keyscan can't reach the host (filtered/flaky), don't hard-fail here —
+# fall back to trust-on-first-use during the real connection, and surface a
+# clear reachability diagnostic so misconfigured host/port issues are obvious.
+if ssh-keyscan -T 10 -p "$SSH_PORT" -H "$SSH_HOST" > "$KNOWN_HOSTS" 2>/dev/null && [ -s "$KNOWN_HOSTS" ]; then
+  SSH_OPTS=(-p "$SSH_PORT" -o "UserKnownHostsFile=$KNOWN_HOSTS" -o "StrictHostKeyChecking=yes")
+else
+  echo "WARN: could not pre-fetch host key for $SSH_HOST:$SSH_PORT — using accept-new (trust on first use)." >&2
+  if command -v nc >/dev/null 2>&1 && ! nc -z -w 5 "$SSH_HOST" "$SSH_PORT" 2>/dev/null; then
+    echo "WARN: TCP connect to $SSH_HOST:$SSH_PORT failed. Check that SSH_HOST/SSH_PORT are correct" >&2
+    echo "      and that the SSH endpoint is reachable (e.g. not behind a proxy/CDN, firewall open)." >&2
+  fi
+  SSH_OPTS=(-p "$SSH_PORT" -o "UserKnownHostsFile=$KNOWN_HOSTS" -o "StrictHostKeyChecking=accept-new")
 fi
-
-SSH_OPTS=(-p "$SSH_PORT" -o "UserKnownHostsFile=$KNOWN_HOSTS" -o "StrictHostKeyChecking=yes")
 
 # Use an explicit key file when the private key is provided (CI); otherwise the
 # user's ssh-agent / default keys are used.


### PR DESCRIPTION
## Sorun

İlk gerçek deploy çalışması (master'a #18 merge'ü sonrası) `tools/deploy.sh` içinde şu hatayla başarısız oldu:

```
ERROR: could not fetch host key for ***:***
```

`ssh-keyscan` ~5 sn'de zaman aşımına uğradı → runner, `SSH_HOST:SSH_PORT`'a TCP bağlantısı kuramadı.

### Kök neden (bağlanabilirlik, script değil)

`kreacad.fabus.app` DNS'i Cloudflare IP aralığına (`2606:4700::…`) çözülüyor — yani alan adı **Cloudflare proxy'si arkasında**. Cloudflare yalnızca HTTP/HTTPS proxy'ler, **SSH'ı geçirmez**. Bu yüzden SSH bağlantısı domaine asla ulaşamaz.

**Gerçek çözüm secret tarafında:** `SSH_HOST`, Cloudflare arkasındaki domain yerine SiteGround'un **gerçek sunucu host'u/IP'si** olmalı (Site Tools → Devs → SSH Keys Manager'da gösterilir), `SSH_PORT` ise genelde `18765`.

## Bu PR'daki değişiklik

Script tarafında bir dayanıklılık iyileştirmesi (`tools/deploy.sh`):

- `ssh-keyscan` başarısız olduğunda **sert hata vermek yerine**, gerçek bağlantı sırasında `StrictHostKeyChecking=accept-new` (trust-on-first-use) ile devam eder.
- `nc` ile bir **TCP erişilebilirlik teşhisi** yazar; böylece yanlış `SSH_HOST`/`SSH_PORT` durumları anında görünür.
- Anahtar başarıyla alınırsa eskisi gibi `StrictHostKeyChecking=yes` ile pinlenir.

> Not: Bu değişiklik teşhisi netleştirir, ama `SSH_HOST` Cloudflare'li domain olarak kaldığı sürece deploy yine başarısız olur. Asıl düzeltme secret'ı SiteGround sunucu host'una/IP'sine güncellemektir.

## Test

- `bash -n tools/deploy.sh` → sözdizimi OK.
- Bağlanabilirlik teşhisi bu ortamdan doğrulandı: `kreacad.fabus.app` → `2606:4700::` (Cloudflare), port 18765 ve 22 filtreli.

https://claude.ai/code/session_019fFDYGgTsqemsWxwDkjHj5

---
_Generated by [Claude Code](https://claude.ai/code/session_019fFDYGgTsqemsWxwDkjHj5)_